### PR TITLE
ci: allow manually triggering the Security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,7 @@
 name: Security
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:


### PR DESCRIPTION
Adds `workflow_dispatch` so the weekly audit can be re-run on demand right after dependency bumps land.